### PR TITLE
Update support for LikeCoin 3.0, Desmos 2.3.1

### DIFF
--- a/cmd/pruner.go
+++ b/cmd/pruner.go
@@ -542,9 +542,19 @@ func pruneAppState(home string) error {
 		}
 	} else if app == "desmos" {
 		desmosKeys := types.NewKVStoreKeys(
-			"posts",     // poststypes.StoreKey,
-			"profiles",  // profilestypes.StoreKey,
-			"subspaces", // subspacestypes.StoreKey,
+			// common modules
+			"feegrant",     // feegrant.StoreKey,
+			"wasm",         // wasm.StoreKey,
+			"authz",        // authzkeeper.StoreKey,
+			// mainnet
+			"profiles",     // profilestypes.StoreKey,
+			// staging
+			"subspaces",    // subspacestypes.StoreKey,
+			"posts",        // poststypes.StoreKey,
+			"relationships, // relationshipstypes.StoreKey,
+			"reports,       // reports.StoreKey,
+			"reactions,     // reactions.StoreKey,
+			"fees,          // fees.StoreKey,
 		)
 
 		for key, value := range desmosKeys {

--- a/cmd/pruner.go
+++ b/cmd/pruner.go
@@ -543,18 +543,18 @@ func pruneAppState(home string) error {
 	} else if app == "desmos" {
 		desmosKeys := types.NewKVStoreKeys(
 			// common modules
-			"feegrant",     // feegrant.StoreKey,
-			"wasm",         // wasm.StoreKey,
-			"authz",        // authzkeeper.StoreKey,
+			"feegrant",      // feegrant.StoreKey,
+			"wasm",          // wasm.StoreKey,
+			"authz",         // authzkeeper.StoreKey,
 			// mainnet
-			"profiles",     // profilestypes.StoreKey,
+			"profiles",      // profilestypes.StoreKey,
 			// staging
-			"subspaces",    // subspacestypes.StoreKey,
-			"posts",        // poststypes.StoreKey,
-			"relationships, // relationshipstypes.StoreKey,
-			"reports,       // reports.StoreKey,
-			"reactions,     // reactions.StoreKey,
-			"fees,          // fees.StoreKey,
+			"subspaces",     // subspacestypes.StoreKey,
+			"posts",         // poststypes.StoreKey,
+			"relationships", // relationshipstypes.StoreKey,
+			"reports",       // reports.StoreKey,
+			"reactions",     // reactions.StoreKey,
+			"fees",          // fees.StoreKey,
 		)
 
 		for key, value := range desmosKeys {

--- a/cmd/pruner.go
+++ b/cmd/pruner.go
@@ -550,7 +550,7 @@ func pruneAppState(home string) error {
 			"authz",         // authzkeeper.StoreKey,
 			// mainnet
 			"profiles",      // profilestypes.StoreKey,
-			// staging
+			// testnet
 			"subspaces",     // subspacestypes.StoreKey,
 			"posts",         // poststypes.StoreKey,
 			"relationships", // relationshipstypes.StoreKey,

--- a/cmd/pruner.go
+++ b/cmd/pruner.go
@@ -282,6 +282,9 @@ func pruneAppState(home string) error {
 			"feegrant", // feegrant.StoreKey,
 			"authz",    // authzkeeper.StoreKey,
 			"iscn",     // iscntypes.StoreKey,
+			"mint",     // minttypes.StoreKey,
+			"nft",      // nftkeeper.StoreKey,
+		        "likenft",  // likenfttypes.StoreKey,
 		)
 
 		for key, value := range likecoinKeys {

--- a/cmd/pruner.go
+++ b/cmd/pruner.go
@@ -281,7 +281,7 @@ func pruneAppState(home string) error {
 		likecoinKeys := types.NewKVStoreKeys(
 			"feegrant", // feegrant.StoreKey,
 			"authz",    // authzkeeper.StoreKey,
-			"iscn",     // iscntypes.StoreKey
+			"iscn",     // iscntypes.StoreKey,
 			"nft",      // nftkeeper.StoreKey,
 		        "likenft",  // likenfttypes.StoreKey,
 		)

--- a/cmd/pruner.go
+++ b/cmd/pruner.go
@@ -279,8 +279,10 @@ func pruneAppState(home string) error {
 		}
 	} else if app == "likecoin" {
 		likecoinKeys := types.NewKVStoreKeys(
+			// common modules
 			"feegrant", // feegrant.StoreKey,
 			"authz",    // authzkeeper.StoreKey,
+			// custom modules
 			"iscn",     // iscntypes.StoreKey,
 			"nft",      // nftkeeper.StoreKey,
 		        "likenft",  // likenfttypes.StoreKey,

--- a/cmd/pruner.go
+++ b/cmd/pruner.go
@@ -281,8 +281,7 @@ func pruneAppState(home string) error {
 		likecoinKeys := types.NewKVStoreKeys(
 			"feegrant", // feegrant.StoreKey,
 			"authz",    // authzkeeper.StoreKey,
-			"iscn",     // iscntypes.StoreKey,
-			"mint",     // minttypes.StoreKey,
+			"iscn",     // iscntypes.StoreKey
 			"nft",      // nftkeeper.StoreKey,
 		        "likenft",  // likenfttypes.StoreKey,
 		)

--- a/cmd/pruner.go
+++ b/cmd/pruner.go
@@ -540,6 +540,16 @@ func pruneAppState(home string) error {
 		for key, value := range umeeKeys {
 			keys[key] = value
 		}
+	} else if app == "desmos" {
+		desmosKeys := types.NewKVStoreKeys(
+			"posts",     // poststypes.StoreKey,
+			"profiles",  // profilestypes.StoreKey,
+			"subspaces", // subspacestypes.StoreKey,
+		)
+
+		for key, value := range desmosKeys {
+			keys[key] = value
+		}
 	}
 
 	// TODO: cleanup app state


### PR DESCRIPTION
There are 2 modules included in the LikeCoin 3.0:
- `nft`
- `likenft`

also, 3 modules included in the Desmos 2.3.1:
- `posts`
- `profiles`
- `subspaces`

so I added their keys so that all of them can be pruned.