### PR TITLE
Release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: "Release to GitHub"
+
+on:
+  push:
+    # Create releases only on tags
+    tags:
+      - "*"
+
+jobs:
+  build:
+    name: GoReleaser build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Go setup
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18.5
+        id: go
+
+      - name: Release binaries
+        uses: goreleaser/goreleaser-action@master
+        with:
+          version: latest
+          args: release --rm-dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,3 +28,5 @@ jobs:
         with:
           version: latest
           args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GO_RELEASER_GITHUB_TOKEN }}


### PR DESCRIPTION
First and foremost, thank you for your work on this project! It is very useful.

I would prefer having the option to download prebuilt binaries, rather than have to build from source every time. I see this has also been requested by the community in issue #9.

This PR implements a [Github action to release binaries](https://github.com/marketplace/actions/goreleaser-action) when a new tag is created.

For more information on how this is set up, please refer to [this article](https://dev.to/koddr/github-action-for-release-your-go-projects-as-fast-and-easily-as-possible-20a2).
