### PR TITLE
fix: add wasm module to axelar

### DIFF
--- a/cmd/pruner.go
+++ b/cmd/pruner.go
@@ -519,6 +519,7 @@ func pruneAppState(home string) error {
 			"axelarnet",  // axelarnetTypes.StoreKey,
 			"reward",     // rewardTypes.StoreKey,
 			"permission", // permissionTypes.StoreKey,
+			"wasm",       // wasm.StoreKey,
 		)
 
 		for key, value := range axelarKeys {


### PR DESCRIPTION
Axelar `v0.35` [upgrade](https://docs.axelar.dev/resources/mainnet/upgrades/v35) enables CosmWasm. So include the `wasm` module when pruning.